### PR TITLE
make it easier to find OKD-WG meetings

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ OKD: The Origin Community Distribution of Kubernetes
 
 This repository covers OKD4 and newer. For older versions of OKD, see the [3.11 branch of openshift/origin](https://github.com/openshift/origin/tree/release-3.11).
 
+The [OKD Working Group](https://github.com/openshift/community#okd-working-group-meetings) meets bi-weekly to discuss development and next steps.  Meeting schedule and location are tracked in the [openshift/community repo](https://github.com/openshift/community/projects/1#card-28309038).
+
 
 Getting Started
 ---------------


### PR DESCRIPTION
The newly-linked repo claims that meeting details will be announced on okd-wg@google e-mail list, but in reality no e-mail messages are sent.