### PR TITLE
Updates oc adm release image url to wildcard

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In order to obtain the openshift installer and client, visit [https://origin-rel
 Use `oc` to download and extract the tools from the image:
 
 ```
-$ oc adm release extract --tools registry.svc.ci.openshift.org/origin/release:4.4.0-0.okd-2020-01-20-084618
+$ oc adm release extract --tools registry.svc.ci.openshift.org/origin/release:4.4
 ```
 
 **NOTE**: You need a 4.x version of `oc` to extract the installer and the latest client. You can initially use the [official Openshift client (mirror)](https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In order to obtain the openshift installer and client, visit [https://origin-rel
 Use `oc` to download and extract the tools from the image:
 
 ```
-$ oc adm release extract --tools registry.svc.ci.openshift.org/origin/release:4.4
+$ oc adm release extract --tools registry.svc.ci.openshift.org/origin/release:4.4.0-0.okd-2020-01-28-022517
 ```
 
 **NOTE**: You need a 4.x version of `oc` to extract the installer and the latest client. You can initially use the [official Openshift client (mirror)](https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/)


### PR DESCRIPTION
The README had a link to a specific version, which as of today is unavailable:

```
> oc adm release extract --tools registry.svc.ci.openshift.org/origin/release:4.4.0-0.okd-2020-01-20-084618
> error: image does not exist
```

It is better to use the 4.4 wildcard url `registry.svc.ci.openshift.org/origin/release:4.4` instead. Unless there is some specific reason to use a certain image I guess.
