### PR TITLE
Fix some typos and whitespaces

### DIFF
--- a/Documentation/UPI/Requirements/DNS_Bind.md
+++ b/Documentation/UPI/Requirements/DNS_Bind.md
@@ -103,7 +103,7 @@ CONTROL_PLANE_2_LAST_OCTECT_IP    IN    PTR    CONTROL_PLANE_2_FQDN.
 COMPUTE_NODE_0_LAST_OCTECT_IP    IN    PTR    COMPUTE_NODE_0_FQDN.
 COMPUTE_NODE_1_LAST_OCTECT_IP    IN    PTR    COMPUTE_NODE_1_FQDN.
 ```
-Replace every last octect and FQDN placeholders accordingly to the configuration of your cluster.
+Replace every last octet and FQDN placeholders accordingly to the configuration of your cluster.
 
 ### Start DNS
 Now that both the main and the reverse zones are configured, you can start the `named` service with the following command:

--- a/Documentation/UPI/Requirements/LB_HAProxy.md
+++ b/Documentation/UPI/Requirements/LB_HAProxy.md
@@ -16,7 +16,7 @@ $ sudo yum install haproxy
 ```
 ### Configure the pools for bootstrapping
 After the installation you need to configure the pools it needs to balance.
-For an OKD installation, HAProxy has to provide load balacing capabilities to the following services:
+For an OKD installation, HAProxy has to provide load balancing capabilities to the following services:
 
  - OKD default route (ports 443 and 80);
  - Kubernetes API/CLI (port 6443);

--- a/Documentation/UPI/libvirt/libvirt.md
+++ b/Documentation/UPI/libvirt/libvirt.md
@@ -27,7 +27,7 @@ Configure a simple webserver to host the ignition configs and the raw image. The
 
 ### Configure libvirt network
 Create a simple NAT network. Even the "default" network created by libvirt is fine.
- 
+
 There's no need to specify the IP reservation at this point, since the VMs don't exist yet. You can add the records in the dhcp block later.
 ```
 <network connections='3'>
@@ -63,26 +63,26 @@ Create a SSH key pair for SSH login to the cluster VMs, and then create your ins
 apiVersion: v1
 baseDomain: YOUR_DOMAIN
 compute:
-- hyperthreading: Enabled   
+- hyperthreading: Enabled
   name: worker
-  replicas: 0 
+  replicas: 0
 controlPlane:
-  hyperthreading: Enabled   
-  name: master 
-  replicas: 3 
+  hyperthreading: Enabled
+  name: master
+  replicas: 3
 metadata:
   name: CLUSTER_NAME
 networking:
   clusterNetwork:
-  - cidr: 10.100.0.0/14 
-    hostPrefix: 23 
+  - cidr: 10.100.0.0/14
+    hostPrefix: 23
   networkType: OpenShiftSDN
-  serviceNetwork: 
+  serviceNetwork:
   - 172.30.0.0/16
 platform:
-  none: {} 
+  none: {}
 pullSecret: 'SECRET FROM RED HAT CLUSTER MANAGER'
-sshKey: 'YOUR SSH PUBLIC KEY' 
+sshKey: 'YOUR SSH PUBLIC KEY'
 ```
 
 Modify it accordingly to the size and the configuration of your cluster and then remember to backup it, because the OpenShift Installer will remove it after generating the Ignition configuration files.
@@ -122,7 +122,7 @@ After the image was pulled and installed, the server will be rebooted by itself.
 When the server is up again wait for the API service and the MachineConfig service to be spawned (check for the ports 6443 and 22623). Check also for the status of the `bootkube.service`.
 
 ### Start the other servers
-**NOTE:** You can start every server in the cluster in the same time of the boostrap server, as they will still waiting for the latter to expose the Kubernetes and MachineConfig API ports. These steps were separated just for convenience.
+**NOTE:** You can start every server in the cluster in the same time of the bootstrap server, as they will still waiting for the latter to expose the Kubernetes and MachineConfig API ports. These steps were separated just for convenience.
 
 Now that the bootstrap server is ready, you can start every server of your cluster.
 Just like the bootstrap server, the control planes and the workers will boot with the official Fedora CoreOS image, that does not contains hyperkube. Since hyperkube is missing the kubelet service will not start and so the cluster bootstrapping.
@@ -179,7 +179,7 @@ By default registry would expect a storage provider to provide an RWX volume, or
 
 If you want the registry to store your container images, follow the [official OpenShift 4 documentation](https://docs.openshift.com/container-platform/4.2/registry/configuring-registry-storage/configuring-registry-storage-baremetal.html) to configure a persistent storage backend. There are many backend you can use, so just choose the more appropriate for your infrastructure.
 
-If you want instead to use an ephemeral registry, just run the following command to use `emptyDir`:  
+If you want instead to use an ephemeral registry, just run the following command to use `emptyDir`:
 `$ oc patch configs.imageregistry.operator.openshift.io cluster --type merge --patch '{"spec":{"managementState":"Managed","storage":{"emptyDir":{}}}}'`
 
 **NOTE:** While `emptyDir` is suitable for non-production or temporary cluster, it is not recommended for production environments.

--- a/Documentation/UPI/vSphere_terraform/README.md
+++ b/Documentation/UPI/vSphere_terraform/README.md
@@ -182,7 +182,7 @@ Extract `openshift-install` tool (e.g. `oc adm release extract --command=openshi
     * control_plane_macs
     * compute_macs
 
-1. Copy `bootstrap.ign` to an accessable webserver. The bootstrap ignition config must be placed in a location that will be accessible by the bootstrap machine. For example, you could store the bootstrap ignition config in a gist.
+1. Copy `bootstrap.ign` to an accessible webserver. The bootstrap ignition config must be placed in a location that will be accessible by the bootstrap machine. For example, you could store the bootstrap ignition config in a gist.
 
 1. Run `terraform init`.
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Learn More
 
 * **[Public Documentation](https://docs.okd.io/latest/welcome/)**
 
-For questions or feedback, reach us on [Kuberenetes Slack on #openshift-dev](https://kubernetes.slack.com/) or post to our [mailing list](https://lists.openshift.redhat.com/openshiftmm/listinfo/dev).
+For questions or feedback, reach us on [Kubernetes Slack on #openshift-dev](https://kubernetes.slack.com/) or post to our [mailing list](https://lists.openshift.redhat.com/openshiftmm/listinfo/dev).
 
 
 ### What can I run on OKD?


### PR DESCRIPTION
Found some spelling mistakes when reading through the docs in my editor. Also fixed the trailing spaces of the install config in the libvirt docs.