### PR TITLE
vSphere UPI: Make disk_size of VMs customizable and increase it to 128GByte.

### DIFF
--- a/Guides/UPI/vSphere_terraform/machine/main.tf
+++ b/Guides/UPI/vSphere_terraform/machine/main.tf
@@ -37,7 +37,7 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label            = "disk0"
-    size             = 60
+    size             = var.disk_size
     thin_provisioned = data.vsphere_virtual_machine.template.disks.0.thin_provisioned
   }
 

--- a/Guides/UPI/vSphere_terraform/main.tf
+++ b/Guides/UPI/vSphere_terraform/main.tf
@@ -41,7 +41,7 @@ module "bootstrap" {
   memory               = "8192"
   num_cpu              = "4"
   num_cores_per_socket = "4"
-  disk_size            = "60"
+  disk_size            = "120"
 }
 
 module "master" {
@@ -61,7 +61,7 @@ module "master" {
   memory               = "16384"
   num_cpu              = "4"
   num_cores_per_socket = "4"
-  disk_size            = "60"
+  disk_size            = "120"
 }
 
 module "compute" {
@@ -81,5 +81,5 @@ module "compute" {
   memory               = "8192"
   num_cpu              = "4"
   num_cores_per_socket = "4"
-  disk_size            = "60"
+  disk_size            = "120"
 }


### PR DESCRIPTION
60GByte is too small after a few upgrades to the cluster have been applied.