### PR TITLE
FAQ: remove non-community catalog tip

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -9,9 +9,6 @@ Below are answers to common questions regarding OKD installation and administrat
 - [What to do in case of errors?](#what-to-do-in-case-of-errors)
 - [Where do I seek support?](#where-do-i-seek-support)
 
-# Post-Installation Configuration #
-- [How can I enable the (non-community) Red Hat Operators?](#how-can-i-enable-the-non-community-red-hat-operators)
-
 # Upgrades #
 - [Where can I find upgrades?](#where-can-i-find-upgrades)
 - [How can I upgrade my cluster to a new version?](#how-can-i-upgrade-my-cluster-to-a-new-version)
@@ -172,33 +169,3 @@ This one is very helpful if you want to know if a certain commit has landed in y
     ...
 
   ```
-
-## How can I enable the (non-community) Red Hat Operators?
-If you have installed OKD with an "official" pull secret which contains ```registry.redhat.io```,
-such as that with which you can install OpenShift, you are entitled to enable the Red Hat operators
-alongside the default community operators.
-
-One reason for doing so, is to enable the "metering-ocp" operator, as the community operators ships
-with a deprecated "metering" operator.
-
-Firstly, ensure that you do have a pull secret which contains ```registry.redhat.io```
-
-Then, update the OperatorHub CR:
-
-```bash
-(
-cat <<EOF
-apiVersion: config.openshift.io/v1
-kind: OperatorHub
-metadata:
-  name: cluster
-spec:
-  disableAllDefaultSources: true
-  sources:
-  - disabled: false
-    name: redhat-operators
-  - disabled: false
-    name: community-operators
-EOF
- ) | oc apply -f -
-```


### PR DESCRIPTION
This section is causing some confusion about support terms and ToS. OKD community would soon have a special catalog with Red Hat operators as a replacement.