### PR TITLE
Change fake pull secret to a parsable value

### DIFF
--- a/Guides/UPI/okd4-terraform-openstack/install-config.yaml
+++ b/Guides/UPI/okd4-terraform-openstack/install-config.yaml
@@ -13,15 +13,15 @@ metadata:
   name: same-name-as-in-terraform.tfvars
 networking:
   clusterNetwork:
-  - cidr: 10.128.0.0/14 
-    hostPrefix: 23 
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
   networkType: OpenShiftSDN
-  serviceNetwork: 
+  serviceNetwork:
   - 172.30.0.0/16
 platform:
   none: {}
 ## The pull secret that provides components in the cluster access to images for OpenShift components.
 # a fake value to satisfy the installer. Images for okd need no subscription
-pullSecret: '{"auths":{"fake":{"auth": "bar"}}}'
+pullSecret: '{"auths":{"fake":{"auth":"aWQ6cGFzcwo="}}}'
 ## The default SSH key that will be programmed for `core` user.
 sshKey: 'ssh-pubkey-for-instance-access'

--- a/Guides/UPI/vSphere_terraform/README.md
+++ b/Guides/UPI/vSphere_terraform/README.md
@@ -154,7 +154,7 @@ Extract `openshift-install` tool (e.g. `oc adm release extract --command=openshi
        password: 'YOUR_VSPHERE_PASSWORD'
        datacenter: 'OCP-Datacenter'
        defaultDatastore: 'iscsi-hdd'
-   pullSecret: '{"auths":{"fake":{"auth": "bar"}}}'
+   pullSecret: '{"auths":{"fake":{"auth":"aWQ6cGFzcwo="}}}'
    sshKey: 'YOUR_SSH_KEY'
    ```
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You'll be prompted to choose a platform to install to - AWS is currently the bes
 
 You will need to have cloud credentials set in your shell properly before installation. You must have permission to configure the appropriate cloud resources from that account (such as VPCs, instances, and DNS records). You must have already configured a public DNS zone on your chosen cloud before the install starts.
 
-You will also be prompted for a pull-secret that will be made available to all of of your machines - for OKD4 you should either paste the pull-secret you use for your registry, or paste `{"auths":{"fake":{"auth": "bar"}}}` to bypass the required value check (see [bug #182](https://github.com/openshift/okd/issues/182)).
+You will also be prompted for a pull-secret that will be made available to all of of your machines - for OKD4 you should either paste the pull-secret you use for your registry, or paste `{"auths":{"fake":{"auth":"aWQ6cGFzcwo="}}}` to bypass the required value check (see [bug #182](https://github.com/openshift/okd/issues/182)).
 
 Once the install completes successfully (usually 30m on AWS) the console URL and an admin username and password will be printed. If your DNS records were correct, you should be able to log in to your new OKD4 cluster!
 


### PR DESCRIPTION
Due to various problems, we should change our fake pull secret example to a fake secret that is parsable.
Related issues:
 - #264
 - #576
 
Note: At the moment I have not tested an okd installation with this pull-secret, but I will do so this week.