### PR TITLE
KNOWN_ISSUES: add a note about systemd crashing fix

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -68,5 +68,6 @@ systemd[1]: Freezing execution.
 
   Because of [two CVEs](https://github.com/coreos/fedora-coreos-tracker/issues/904) package updates were fast-tracked. Afterwards, as noted in [an issue](https://github.com/coreos/fedora-coreos-tracker/issues/912) and [Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=1984651), systemd may respond as if sent an ABRT signal and crash. Differences between systemd-248.5 and 248.6 are listed at [Bodhi](https://bodhi.fedoraproject.org/updates/FEDORA-2021-3141f0eff1). A [commit](https://github.com/openshift/okd-machine-os/pull/181) to remove the package exceptions from okd-machine-os was made in mid-August 2021.
 
-  **Workaround:** Reboot the machine when systemd crashes.
+  Updated systemd package landed in 4.7.0-0.okd-2021-08-22-163618
 
+  **Workaround:** Reboot the machine when systemd crashes.


### PR DESCRIPTION
Add a note that systemd has been updated in 4.7.0-0.okd-2021-08-22-163618

cc @ptudor 