### PR TITLE
Updated FAQ to accurately reflect status of single-node cluster installations

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -58,7 +58,9 @@ The OKD stable version is released bi-weekly, following Fedora CoreOS schedule, 
 
 ## Can I run a single node cluster?
 
-Currently, single-node cluster installations cannot be deployed directly by the installer. There must be at least 3 control nodes and 2 compute nodes. You may have luck with Charo Gruver's [OKD 4 Single Node Cluster instructions](https://cgruver.github.io/okd4-single-node-cluster/). You can also use [Code Ready Containers (CRC)](https://www.okd.io/crc.html) to run a single-node cluster on your desktop.
+Currently, single-node cluster installations cannot be deployed directly by the 4.7 installer. This is a [known issue](https://github.com/openshift/okd/blob/master/KNOWN_ISSUES.md). Single-node cluster installations do work with the 4.8 nightly installer builds. 
+
+As an alternative, if OKD version 4.7 is needed, you may have luck with Charo Gruver's [OKD 4 Single Node Cluster instructions](https://cgruver.github.io/okd4-single-node-cluster/). You can also use [Code Ready Containers (CRC)](https://www.okd.io/crc.html) to run a single-node cluster on your desktop.
 
 ## What to do in case of errors?
 If you experience problems during installation you *must* collect the bootstrap log bundle, see [instructions](https://docs.okd.io/latest/installing/installing-troubleshooting.html)

--- a/FAQ.md
+++ b/FAQ.md
@@ -58,20 +58,7 @@ The OKD stable version is released bi-weekly, following Fedora CoreOS schedule, 
 
 ## Can I run a single node cluster?
 
-Yes.
-
-Set the following in install config, which renders 0 worker nodes and 1 control-plane node:
-```
-compute:
-- name: worker
-  replicas: 0
-controlPlane:
-  name: master
-  replicas: 1
-```
-This would inject a non-HA manifest for etcd and run a single ingress pod.
-
-WARNING: this cluster cannot be upgraded or adjusted via MachineConfigs. Adding more masters is not yet supported.
+Currently, single-node cluster installations cannot be deployed directly by the installer. There must be at least 3 control nodes and 2 compute nodes. You may have luck with Charo Gruver's [OKD 4 Single Node Cluster instructions](https://cgruver.github.io/okd4-single-node-cluster/). You can also use [Code Ready Containers (CRC)](https://www.okd.io/crc.html) to run a single-node cluster on your desktop.
 
 ## What to do in case of errors?
 If you experience problems during installation you *must* collect the bootstrap log bundle, see [instructions](https://docs.okd.io/latest/installing/installing-troubleshooting.html)

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -1,5 +1,13 @@
 # Frequent issues in latest releases
 
+## [Single-node Cluster Installations Fails on AWS (IPI)](https://github.com/openshift/okd/issues/862)
+
+  **Effected Versions:** 4.7
+
+  **Description:** Attempting to deploy a single-node cluster to AWS with Installer Provisioned Infrastructure (IPI) fails.
+
+  **Workaround:** None at this time. 
+
 ## CannotRetrieveUpdates alert
 
   **Effected Versions:** All


### PR DESCRIPTION
Various tests have shown this is not possible with versions >4.5 using just the installer. It consistently fails with less than three control nodes. 